### PR TITLE
rockspec specifies proper git tag

### DIFF
--- a/loadcaffe-1.0-0.rockspec
+++ b/loadcaffe-1.0-0.rockspec
@@ -3,7 +3,7 @@ version = "1.0-0"
 
 source = {
    url = "git://github.com/szagoruyko/loadcaffe",
-   tag = "1.0-0"
+   tag = "master"
 }
 
 description = {


### PR DESCRIPTION
i am going to add this to the torch/rocks repo, so as a prerequisite fixing the rockspec.
