### PR TITLE
set net to "test" mode (disable dropout)

### DIFF
--- a/test/generate.lua
+++ b/test/generate.lua
@@ -52,6 +52,7 @@ table.insert(nets_list, {
 
 for i,netprops in ipairs(nets_list) do
   net = caffe.Net(netprops.proto, netprops.binary)
+  net:setPhaseTest()
   netprops.output = net:forward(netprops.input)
   net:reset()
 end


### PR DESCRIPTION
The net loaded by the Caffe bindings is by default in "train" mode and will do dropouts if they are part of the net.
In that mode, the outputs varies for different calls on the same input:

``` lua
require 'caffe'
net = caffe.Net('VGG_ILSVRC_16_layers_deploy.prototxt', 'VGG_ILSVRC_16_layers.caffemodel')
input = torch.FloatTensor(10,3,224,224)
print(net:forward(input:clone())[1]:squeeze():sub(1, 2))
> 0.001 *
 0.1116
 1.2804
> print(net:forward(input:clone())[1]:squeeze():sub(1, 2))
0.001 *
 0.3171
 0.7601
```

Setting it to "test" mode fixes the problem:

``` lua
require 'caffe'
net = caffe.Net('VGG_ILSVRC_16_layers_deploy.prototxt', 'VGG_ILSVRC_16_layers.caffemodel')
net:setPhaseTest()
input = torch.FloatTensor(10,3,224,224)
print(net:forward(input:clone())[1]:squeeze():sub(1, 2))
> 0.001 *
 0.1946
 2.0981
> print(net:forward(input:clone())[1]:squeeze():sub(1, 2))
0.001 *
 0.1946
 2.0981
```
