### PR TITLE
Fix print of numeric data when locale decimal_point is not dot.

### DIFF
--- a/loadcaffe.cpp
+++ b/loadcaffe.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <TH/TH.h>
+#include <locale.h>
 
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -94,6 +95,7 @@ void convertProtoToLuaV1(const caffe::NetParameter &netparam, const char* lua_na
   else if(std::string(cuda_package) == "cudnn")
     cuda_package_type = CUDNN;
 
+  setlocale(LC_NUMERIC,"C");
   std::ofstream ofs (lua_name);
 
   ofs << "require '" << cuda_package << "'\n";
@@ -314,6 +316,7 @@ void convertProtoToLuaV2(const caffe::NetParameter &netparam, const char* lua_na
   else if(std::string(cuda_package) == "cudnn")
     cuda_package_type = CUDNN;
 
+  setlocale(LC_NUMERIC,"C");
   std::ofstream ofs (lua_name);
 
   ofs << "require '" << cuda_package << "'\n";

--- a/loadcaffe.cpp
+++ b/loadcaffe.cpp
@@ -12,7 +12,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <TH/TH.h>
-#include <locale.h>
+#include <locale>
 
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -77,6 +77,7 @@ enum PACKAGE_TYPE {
 
 void convertProtoToLua(void** handle, const char* lua_name, const char* cuda_package)
 {
+  std::locale::global(std::locale());
   const caffe::NetParameter netparam = *(const caffe::NetParameter*)handle[1];
   if (netparam.layers_size() > 0)
       convertProtoToLuaV1(netparam, lua_name, cuda_package);
@@ -95,7 +96,6 @@ void convertProtoToLuaV1(const caffe::NetParameter &netparam, const char* lua_na
   else if(std::string(cuda_package) == "cudnn")
     cuda_package_type = CUDNN;
 
-  setlocale(LC_NUMERIC,"C");
   std::ofstream ofs (lua_name);
 
   ofs << "require '" << cuda_package << "'\n";
@@ -316,7 +316,6 @@ void convertProtoToLuaV2(const caffe::NetParameter &netparam, const char* lua_na
   else if(std::string(cuda_package) == "cudnn")
     cuda_package_type = CUDNN;
 
-  setlocale(LC_NUMERIC,"C");
   std::ofstream ofs (lua_name);
 
   ofs << "require '" << cuda_package << "'\n";


### PR DESCRIPTION
On computers were the standard delimiter is a comma (like the French one), `loadcaffe` would fail to load fractional parameters.