### PR TITLE
Improve cpu support

### DIFF
--- a/loadcaffe.cpp
+++ b/loadcaffe.cpp
@@ -99,12 +99,9 @@ void convertProtoToLuaV1(const caffe::NetParameter &netparam, const char* lua_na
   std::ofstream ofs (lua_name);
 
   ofs << "require '" << cuda_package << "'\n";
-  ofs << "require 'cunn'\n";
   ofs << "local model = {}\n";
   if(std::string(cuda_package)=="ccn2")
     ofs<< "table.insert(model, {'torch_transpose_dwhb', nn.Transpose({1,4},{1,3},{1,2})})\n";
-  else if(std::string(cuda_package)=="nn" || std::string(cuda_package)=="cudnn")
-    ofs<< "require 'inn'\n";
 
   int num_output = netparam.input_dim_size();
   for (int i=0; i<netparam.layers_size(); ++i)
@@ -351,12 +348,9 @@ void convertProtoToLuaV2(const caffe::NetParameter &netparam, const char* lua_na
   std::ofstream ofs (lua_name);
 
   ofs << "require '" << cuda_package << "'\n";
-  ofs << "require 'cunn'\n";
   ofs << "local model = {}\n";
   if(std::string(cuda_package)=="ccn2")
     ofs<< "table.insert(model, {'torch_transpose_dwhb', nn.Transpose({1,4},{1,3},{1,2})})\n";
-  else if(std::string(cuda_package)=="nn" || std::string(cuda_package)=="cudnn")
-    ofs<< "require 'inn'\n";
 
   int num_output = netparam.input_shape_size() * 4;
 

--- a/loadcaffe.lua
+++ b/loadcaffe.lua
@@ -16,7 +16,11 @@ loadcaffe.load = function(prototxt_name, binary_name, backend)
   local lua_name = prototxt_name..'.lua'
   C.convertProtoToLua(handle, lua_name, backend)
 
-  -- executes the script, defining global 'model' module list
+  -- executes the script
+  local model_definition = io.open(lua_name):read'*all'
+  if (model_definition:find'inn%.') then
+    require 'inn'
+  end
   local model = dofile(lua_name)
 
   -- goes over the list, copying weights from caffe blobs to torch tensor


### PR DESCRIPTION
Disable `require 'cunn'` and `require 'inn'` calls by default, require inn only if a module is needed