### PR TITLE
ceil avg pooling from cunn

### DIFF
--- a/loadcaffe.cpp
+++ b/loadcaffe.cpp
@@ -220,7 +220,7 @@ void convertProtoToLuaV1(const caffe::NetParameter &netparam, const char* lua_na
             if(param.pool() == caffe::PoolingParameter::MAX)
               sprintf(buf, "nn.SpatialMaxPooling(%d, %d, %d, %d, %d, %d):ceil()", kW, kH, dW, dH, padW, padH);
             else if(param.pool() == caffe::PoolingParameter::AVE)
-              sprintf(buf, "inn.SpatialAveragePooling(%d, %d, %d, %d)", kW, kH, dW, dH); // padding is not supported yet
+              sprintf(buf, "nn.SpatialAveragePooling(%d, %d, %d, %d):ceil()", kW, kH, dW, dH); // padding is not supported yet
             else if(param.pool() == caffe::PoolingParameter::STOCHASTIC)
               sprintf(buf, "inn.SpatialStochasticPooling(%d, %d, %d, %d)", kW, kH, dW, dH);
             break;
@@ -468,7 +468,7 @@ void convertProtoToLuaV2(const caffe::NetParameter &netparam, const char* lua_na
           if(param.pool() == caffe::PoolingParameter::MAX)
             sprintf(buf, "nn.SpatialMaxPooling(%d, %d, %d, %d, %d, %d):ceil()", kW, kH, dW, dH, padW, padH);
           else if(param.pool() == caffe::PoolingParameter::AVE)
-            sprintf(buf, "inn.SpatialAveragePooling(%d, %d, %d, %d)", kW, kH, dW, dH); // padding is not supported yet
+            sprintf(buf, "nn.SpatialAveragePooling(%d, %d, %d, %d):ceil()", kW, kH, dW, dH); // padding is not supported yet
           else if(param.pool() == caffe::PoolingParameter::STOCHASTIC)
             sprintf(buf, "inn.SpatialStochasticPooling(%d, %d, %d, %d)", kW, kH, dW, dH);
           break;


### PR DESCRIPTION
This reverts commit 4762b38a99023a127a4c235ceee0a3d344e0f204.

enable nn.SpatialAveragePooling ceil instead of inn version