### PR TITLE
Only observe kernel dims when in a conv layer

### DIFF
--- a/loadcaffe.cpp
+++ b/loadcaffe.cpp
@@ -643,8 +643,6 @@ void loadModuleV2(const caffe::NetParameter* netparam, const char* name, THFloat
     {
       int nInputPlane = layer.blobs(0).shape().dim(1);
       int nOutputPlane = layer.blobs(0).shape().dim(0);
-      int kW = layer.blobs(0).shape().dim(3);
-      int kH = layer.blobs(0).shape().dim(2);
       if(layer.type() == "InnerProduct")
       {
         printf("%s: %d %d %d %d\n", name, 1, 1, nInputPlane, nOutputPlane);
@@ -653,6 +651,8 @@ void loadModuleV2(const caffe::NetParameter* netparam, const char* name, THFloat
       }
       else
       {
+	int kW = layer.blobs(0).shape().dim(3);
+	int kH = layer.blobs(0).shape().dim(2);
         printf("%s: %d %d %d %d\n", name, nOutputPlane, nInputPlane, kW, kH);
         THFloatTensor_resize4d(weight, nOutputPlane, nInputPlane, kW, kH);
         memcpy(THFloatTensor_data(weight), layer.blobs(0).data().data(), sizeof(float)*nOutputPlane*nInputPlane*kW*kH);


### PR DESCRIPTION
Apparently, the SCM version of Caffe no longer initializes the second and third dimensions of `InnerProductLayer`'s `BlobShape` ([old](https://github.com/BVLC/caffe/blob/682d9da0dba98788dd01723a16a257df4382376c/src/caffe/layers/inner_product_layer.cpp#L29), [new](https://github.com/BVLC/caffe/blob/master/src/caffe/layers/inner_product_layer.cpp#L34))

Loading such a layer reports the error:
```
[libprotobuf FATAL /.../google/protobuf/repeated_field.h:665] CHECK failed: (index) < (size()):
C++ exception
```

This PR causes the kernel size dimensions to only be checked when in a not-IP layer.