### PR TITLE
add build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 *.exe
 *.out
 *.app
+
+build/


### PR DESCRIPTION
Hi Sergey,

I added loadcaffe to distro-cl, https://github.com/hughperkins/distro-cl/commit/66fda53343cf662d1a50da75eda94e2719bba968 

But ... it causes `git status` to report that the submodule has been updated, because the `build` directory is not in `.gitignore`.

This PR adds `build/` directory to `.gitignore`, to fix this issue.